### PR TITLE
feat: run as container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+from centos:8
+#from fedora:32
+
+LABEL name="snowdrop-automation-client"
+LABEL version="latest"
+
+ENV NVM_VERSION 8.17.0
+# ENV NODE_VERSION 6.4.13
+ENV NVM_INSTALL_SCRIPT_VERSION 0.35.3
+ENV HOME /home/nvm
+ENV NVM_DIR $HOME/.nvm
+
+# python3 is required on centos 8 but not on fedora 32.
+RUN yum install -y --allowerasing curl coreutils \
+        make \
+        gcc gcc-c++ kernel-devel \
+        java-1.8.0-openjdk-devel \
+        git                     \
+        python3                 \ 
+    && yum clean all && rm -rf /var/cache/yum
+
+RUN useradd -ms /bin/bash nvm
+
+USER nvm
+
+WORKDIR $HOME
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$NVM_INSTALL_SCRIPT_VERSION/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install $NVM_VERSION \
+    && nvm alias default $NVM_VERSION \
+    && nvm use default
+
+ENV NODE_PATH $NVM_DIR/versions/node/v$NVM_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/versions/node/v$NVM_VERSION/bin:$PATH
+
+RUN mkdir snowdrop-automation-client
+
+WORKDIR snowdrop-automation-client
+
+COPY --chown=nvm . .
+
+RUN chmod +x container-entrypoint.sh
+
+RUN npm --cache /tmp/empty-cache install && npm run clean && npm run compile
+# TODO: && npm run test
+
+ENTRYPOINT ["./container-entrypoint.sh"]
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
 # snowdrop-automation-client
 
 ## Table of contents
+
    * [snowdrop-automation-client](#snowdrop-automation-client)
+      * [Table of contents](#table-of-contents)
       * [Basics](#basics)
       * [Running](#running)
          * [Prerequisites](#prerequisites)
          * [Launch application](#launch-application)
-      * [Install specific vnm version](#install-specific-vnm-version)
+      * [Install specific nvm version](#install-specific-nvm-version)
       * [Miscellaneous](#miscellaneous)
+      * [Run in a container](#run-in-a-container)
+         * [buildah/podman](#buildahpodman)
+            * [Building the container](#building-the-container)
+            * [Running the container](#running-the-container)
+            * [k8s](#k8s)
+         * [Docker](#docker)
+            * [Build with docker-compose](#build-with-docker-compose)
+            * [Run with docker](#run-with-docker)
+      * [References](#references)
+
+## Introduction
 
 Contains automation used by the snowdrop team
 
@@ -80,3 +93,72 @@ Run tests: `npm run test` (will need an env var named GITHUB_TOKEN to be present
 Run a single test: `TEST=${TEST_FILE_NAME} npm run test:one`
 
 Lint code (and fix issues automatically): `npm run lint:fix`
+
+## Run as container
+
+The `snowdrop-automation-client` can be ran in a container. This allows having a ready to use environment which isn't affected by local npm or JDK versions, as has been proved to affect the behavior of the application.
+
+To build the container a [`Dockerfile`](Dockerfile) has been prepared.
+
+### buildah/podman
+
+#### Building the container
+
+Remove the existing container.
+
+```bash
+$ podman image rm localhost/snowdrop-automation-client
+```
+
+Build the new container using the `Dockerfile`.
+
+```bash
+$ buildah build-using-dockerfile --tag snowdrop-automation-client
+```
+
+#### Running the container
+
+The information described in the [prerequisites](#prerequisites) is not built inside the contaienr and needs to be passed as environment variables. This can be easily done using a file with environement variables.
+
+> NOTE: This file should be out of the git repository folder.
+
+An example of such a file is the following...
+
+```environement
+ATOMIST_CONFIG={"apiKey":"API_KEY","workspaceIds":["WORKSPACE_ID"]}
+SENDGRIDKEY=SENDGRIDKEY_KEY
+```
+
+...replace the `API_KEY`, `WORKSPACE_ID` and `SENDGRIDKEY_KEY` as described above at the [prerequisites](#prerequisites) section.
+
+Start the container with podman.
+
+```bash
+$ podman run --rm --env-file ../snowdrop-automation-client.properties --name snowdrop-automation-client localhost/snowdrop-automation-client
+```
+
+> NOTE: The `--rm` flag is optional and removes the container once it's finished.
+
+#### k8s
+
+Once the container is running it's possible to generate a kubernetes `yaml` file using podman...
+
+```bash
+$ podman generate kube snowdrop-automation-client > snowdrop-automation-client.yml
+```
+
+### Docker
+
+*TBD...*
+
+#### Build with `docker-compose`
+
+*TBD...*
+
+#### Run with docker
+
+*TBD...*
+
+## References
+
+* RedHat: [Podman can now ease the transition to Kubernetes and CRI-O](https://developers.redhat.com/blog/2019/01/29/podman-kubernetes-yaml/) blog article

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+printf "Starting snowdrop-automation-client (%s)..." "$(pwd)"
+
+if [[ -n "${SENDGRIDKEY+x}" ]];
+then
+  export SENDGRIDKEY=${SENDGRIDKEY}
+fi
+
+exec "$@"


### PR DESCRIPTION
Use the snowdrop-automation-client as a container. Build is done using a Dockerfile with [buildah](https://buildah.io/) and the container is ran using [podman](https://podman.io/).

Closes #65 