### PR TITLE
feat: adapt the sb version name validations to 2.4 

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,6 +5,7 @@ export const SPRING_BOOT_VERSION_PROPERTY_NAME = "spring-boot.version";
 
 export const BOM_REPO = "spring-boot-bom";
 export const BOOSTER_CATALOG_REPO = "launcher-booster-catalog";
+
 export const BOM_VERSION_REGEX = /^(\d+.\d+.\d+).(\w+)$/;
 
 export const REDHAT_QUALIFIER = "redhat";
@@ -12,6 +13,6 @@ export const REDHAT_QUALIFIER = "redhat";
 export const BOOSTER_VERSION_REGEX = /^(\d+.\d+.\d+)-(\d+)(-\w+)?$/;
 export const BOOSTER_NAME_REGEX = /^(.+)-example$/;
 
-export const SPRING_BOOT_VERSION_REGEX = /^(\d+.\d+.\d+).RELEASE$/;
+export const SPRING_BOOT_VERSION_REGEX = /^(\d+.\d+.\d+)(.RELEASE)?$/;
 
 export const LICENSES_GENERATOR_PATH = "etc/licenses-generator-shaded.jar";

--- a/lib/support/utils/versions.ts
+++ b/lib/support/utils/versions.ts
@@ -1,5 +1,5 @@
-import {logger} from "@atomist/automation-client";
-import {BOM_VERSION_REGEX, BOOSTER_VERSION_REGEX} from "../../constants";
+import { logger } from "@atomist/automation-client";
+import { BOM_VERSION_REGEX, BOOSTER_VERSION_REGEX } from "../../constants";
 
 export function versionToBranch(version: string): string {
   const versionRegex = /^\d+.\d+/;
@@ -34,5 +34,9 @@ export function bomVersionToSpringBootVersion(bomVersion: string): string {
     throw new Error(`Unsupported version format '${bomVersion}'`);
   }
   const matches = bomVersion.match(BOM_VERSION_REGEX);
-  return `${matches[1]}.RELEASE`;
+  if (bomVersion.startsWith("2.3") || bomVersion.startsWith("2.2")) {
+    return `${matches[1]}.RELEASE`;
+  } else {
+    return `${matches[1]}`;
+  }
 }


### PR DESCRIPTION
Version `2.4` does not have the RELEASE suffix.