### PR TITLE
fix: the new sb version has a minimum length smaller than 10

### DIFF
--- a/lib/commands/AlignBomWithUpstream.ts
+++ b/lib/commands/AlignBomWithUpstream.ts
@@ -28,7 +28,7 @@ export class AlignBomWithUpstream implements HandleCommand {
     description: "Spring Boot version for which we want to run the update (e.g. 2.2.5.RELEASE)",
     pattern: SPRING_BOOT_VERSION_REGEX,
     validInput: "2.2.5.RELEASE",
-    minLength: 10,
+    minLength: 5,
     maxLength: 50,
     required: true,
   })

--- a/lib/commands/ReleaseExamples.ts
+++ b/lib/commands/ReleaseExamples.ts
@@ -31,7 +31,7 @@ export class ReleaseExamples implements HandleCommand {
     description: "Upstream Spring Boot version (e.g. 2.2.5.RELEASE)",
     pattern: SPRING_BOOT_VERSION_REGEX,
     validInput: "2.2.5.RELEASE",
-    minLength: 10,
+    minLength: 5,
     maxLength: 50,
     required: true,
   })

--- a/lib/commands/ReleaseSingleExample.ts
+++ b/lib/commands/ReleaseSingleExample.ts
@@ -24,7 +24,7 @@ export class ReleaseSingleExample implements HandleCommand {
     description: "Upstream Spring Boot version (e.g. 2.2.5.RELEASE)",
     pattern: SPRING_BOOT_VERSION_REGEX,
     validInput: "2.2.5.RELEASE",
-    minLength: 10,
+    minLength: 5,
     maxLength: 50,
     required: true,
   })


### PR DESCRIPTION
Changed the `minlength` parameter value to 5 for the Spring Boot version parameters.