### PR TITLE
fix: reduced minlegth for Create launcher PR command

### DIFF
--- a/lib/commands/CreateLauncherPR.ts
+++ b/lib/commands/CreateLauncherPR.ts
@@ -36,7 +36,7 @@ export class CreateLauncherPR implements HandleCommand {
     description: "The Spring Boot version - something like: 2.1.12.RELEASE",
     pattern: /^\d+.\d+.\d+.*$/,
     validInput: "2.1.12.RELEASE",
-    minLength: 13,
+    minLength: 5,
     maxLength: 14,
     required: true,
   })


### PR DESCRIPTION
The minlength was 13 but the correct value is 5 as a version can have only 3 numbers plus the 2 dots, e.g., 2.4.3