### PR TITLE
chore: bump sdk java version as the previous doesn't exist anymore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
         command: |
           curl -s "https://get.sdkman.io" | bash
           source "$HOME/.sdkman/bin/sdkman-init.sh"
-          sdk install java 11.0.8.hs-adpt
+          sdk install java 11.0.11.hs-adpt
     - run:
         name: build
         command: |


### PR DESCRIPTION
Closes #123 